### PR TITLE
fix modern CIDER compatibility

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -3,7 +3,7 @@
   :url "http://example.com/FIXME"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[org.clojure/clojure "1.6.0"]]
+  :dependencies [[org.clojure/clojure "1.9.0"]]
   :target-path "target/%s"
   :aot [fitness.safety.UnsafeResistanceException]
   :profiles {:uberjar {:aot :all}})


### PR DESCRIPTION
Modern versions of CIDER [require at least Clojure 1.7](http://cider.readthedocs.io/en/stable/installation/#prerequisites).